### PR TITLE
Added blab as grammar based fuzzer

### DIFF
--- a/fuzzer/fuzzer_list.py
+++ b/fuzzer/fuzzer_list.py
@@ -26,5 +26,12 @@ fuzzers = {
         "file": "dharma/dharma/dharma.py",
         "args": '-grammars %(grammar)s -seed %(seed)s > %(output)s',
         "type": "gen"
+    },
+    "Blab":
+    {
+        "name": "Blab",
+        "file": "blab/bin/blab",
+        "args": '-e "$(cat %(grammar)s)" -o %(output)s',
+        "type": "gen"
     }
 }


### PR DESCRIPTION
This PR adds Blab fuzzer to ffw : https://github.com/aoh/blab
Grammar files can contain what is detailes in the blabl Readme.md
Example: A grammar file containing (97 | 98)* 10 will output:
baaaabbbbaaabababaaaababaaabbbababaaaabbbbbabbbbaabbbaaababbbbbb
