### PR TITLE
Fix honggmode

### DIFF
--- a/honggmode/honggcomm.py
+++ b/honggmode/honggcomm.py
@@ -14,7 +14,7 @@ class HonggComm(object):
     def openSocket(self, fuzzerPid):
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
 
-        server_address = '/tmp/honggfuzz_socket.' + str(fuzzerPid)
+        server_address = '/tmp/honggfuzz_socket'
         sys.stdout.write('connecting to honggfuzz socket: %s... ' % server_address)
         while True:
             try:

--- a/honggmode/honggslave.py
+++ b/honggmode/honggslave.py
@@ -266,7 +266,6 @@ class HonggSlave(object):
         if self.config["debug"]:
             # enable debug mode with log to file
             cmdArr.append("-d")
-            cmdArr.append("4")
             cmdArr.append('-l')
             cmdArr.append('honggfuzz.log')
 


### PR DESCRIPTION
Remove pid from the socket name and incorrect number after -d.

Perhaps for the socket change, honggfuzz should be updated instead.
Let me know and I will update this (and open a PR with honggfuzz).